### PR TITLE
Update Linux build step for cmake 3.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,10 @@ or [build them from sources](#building-from-sources).
 1. Navigate to the `scantailor-advanced-x.x.x` directory (`cd "<dir>"`) and enter:
 
    ~~~~
-   mkdir build; cd build
-   cmake -G "Unix Makefiles" --build ..
-   make -j `nproc`
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ~~~~
 
 2. Optionally, install ScanTailor Advanced with:


### PR DESCRIPTION
Update the Linux build instructions for cmake 3.22 as given by @lockywolf in issue #6.

Closes #6.